### PR TITLE
bug in set method when Meteor.call is used

### DIFF
--- a/lib/pages.coffee
+++ b/lib/pages.coffee
@@ -139,7 +139,7 @@
     else
       cb = @reload.bind @
     if Meteor.isClient and onServer
-      @call "Set", k, v, cb
+      Meteor.call @getMethod("Set"), k, v, cb
     if v?
       changes = @_set k, v, init
     else


### PR DESCRIPTION
@call don't use any arguments for Meteor.call (other than callback that must be a function) so it will ignore key and value. This causes a bug where using set on client side won't work.
