### PR TITLE
Modified iron-router route names. Updates for 0.9.4

### DIFF
--- a/client/controllers.coffee
+++ b/client/controllers.coffee
@@ -1,4 +1,4 @@
-_.extend Template['_pagesPageCont'],
+Template._pagesPageCont.helpers
   divWrapper: (self) ->
     self.divWrapper
   table: (self) ->
@@ -6,7 +6,7 @@ _.extend Template['_pagesPageCont'],
   tableWrapper: (self) ->
     self.table.wrapper
 
-_.extend Template['_pagesTable'],
+Template._pagesTable.helpers
   class: (self) ->
     self.table.class or ""
   fields: (self) ->
@@ -14,7 +14,7 @@ _.extend Template['_pagesTable'],
   header: (self) ->
     _.map (self.table.header or self.table.fields), (v) -> value: v
 
-_.extend Template['_pagesPage'],
+Template._pagesPage.helpers
   ready: ->
     return true  if @fastRender
     @sess "ready"
@@ -31,7 +31,7 @@ _.extend Template['_pagesPage'],
   item: ->
     Template[@_t]
 
-_.extend Template['_pagesNav'],
+Template._pagesNav.helpers
   show: ->
     @fastRender or (not @infinite and 1 < @sess "totalPages")
   link: ->
@@ -47,8 +47,9 @@ _.extend Template['_pagesNav'],
     "#"
   paginationNeighbors: ->
     @paginationNeighbors()
-  events:
-    "click a": (e) ->
+
+Template._pagesNav.events
+  "click a": (e) ->
       n = e.target.parentNode.parentNode.parentNode.getAttribute 'data-pages'
       self = Meteor.Pagination::instances[n]
       (_.throttle (e, self, n) ->
@@ -57,12 +58,12 @@ _.extend Template['_pagesNav'],
           self.onNavClick.call self, n
       , self.rateLimit * 1000)(e, self, @n)
 
-_.extend Template['_pagesTableItem'],
+Template._pagesTableItem.helpers
   attrs: (self) ->
     _.map self.table.fields, ((n) ->
       value: if @[n]? then @[n] else ""
     ).bind @
 
-_.extend Template['_pagesItemDefault'],
+Template._pagesItemDefault.helpers
   properties: ->
     _.compact _.map @, (v, k) -> if k[0] isnt "_" then name: k, value: v else null

--- a/lib/pages.coffee
+++ b/lib/pages.coffee
@@ -190,17 +190,17 @@
     else
       isNew = true
       try
-        @Collection = new Meteor.Collection collection
+        @Collection = new Mongo.Collection collection
         Pages::collections[@name] = @Collection
       catch e
         isNew = false
         @Collection = Pages::collections[@name]
-        @Collection instanceof Meteor.Collection or throw "The '#{collection}' collection 
+        @Collection instanceof Mongo.Collection or throw "The '#{collection}' collection 
         was created outside of <Meteor.Pagination>. Pass the collection object
         instead of the collection's name to the <Meteor.Pagination> constructor."
     @setId @Collection._name
-    @PaginatedCollection = new Meteor.Collection @id
-    @PreloadedData = new Meteor.Collection @id + "_data"
+    @PaginatedCollection = new Mongo.Collection @id
+    @PreloadedData = new Mongo.Collection @id + "_data"
   setRouter: ->
     if @router is "iron-router"
       pr = "#{@route}:n"
@@ -210,7 +210,7 @@
       init = true
       Router.map ->
         if self.homeRoute
-          @route "home",
+          @route "#{self.name}_home",
             path: self.homeRoute
             template: t
             layoutTemplate: l
@@ -218,7 +218,7 @@
               self.sess "oldPage", 1
               self.sess "currentPage", 1
         unless self.infinite
-          @route "page",
+          @route "#{self.name}_page",
             path: pr
             template: t
             layoutTemplate: l
@@ -239,8 +239,8 @@
     if @table and @itemTemplate is "_pagesItemDefault"
       @itemTemplate = @tableItemTemplate
     for i in [@navTemplate, @pageTemplate, @itemTemplate, @tableTemplate]
-      Template[i].pagesData = @
-    _.extend Template[name],
+      Template[i].helpers pagesData: @
+    Template[name].helpers
       pagesData: @
       pagesNav: Template[@navTemplate]
       pages: Template[@pageTemplate]
@@ -446,7 +446,7 @@
           sort: @sort
           skip: if @infiniteItemsLimit isnt Infinity and n > @infiniteItemsLimit then n - @infiniteItemsLimit else 0
           limit: @infiniteItemsLimit
-        ).fetch()
+        )
       else #if page in @received
         c = @PaginatedCollection.find(
           _.object([

--- a/package.js
+++ b/package.js
@@ -1,37 +1,37 @@
 Package.describe({
   "name": "alethes:pages",
   "summary": "State of the art, out of the box Meteor pagination",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "git": "https://github.com/alethes/meteor-pages"
 });
 
-Package.on_use(function(api){
-    api.versionsFrom("METEOR@0.9.2.2")
+Package.onUse(function(api){
+    api.versionsFrom("METEOR@0.9.4")
     api.use([
-        "deps",
+        "tracker",
         "underscore",
         "coffeescript"
     ]);
 
     api.use([
         "templating",
-        "handlebars",
-        "ui",
+        "spacebars",
+        "blaze",
         "session"
     ], "client");
 
     api.use([
-        "deps",
+        "tracker",
         "underscore",
         "coffeescript",
         "check"
     ], "server");
 
-    api.add_files([
+    api.addFiles([
         "lib/pages.coffee"
     ]);
 
-    api.add_files([
+    api.addFiles([
         "client/templates.html",
         "client/controllers.coffee",
         "client/main.css",
@@ -39,34 +39,34 @@ Package.on_use(function(api){
     ], "client");
 });
 
-Package.on_test(function(api){
-    api.versionsFrom("METEOR@0.9.0")
+Package.onTest(function(api){
+    api.versionsFrom("METEOR@0.9.4")
     api.use([
-        "deps",
+        "tracker",
         "underscore",
         "coffeescript"
     ]);
 
     api.use([
         "templating",
-        "handlebars",
-        "ui",
+        "spacebars",
+        "blaze",
         "session"
     ], "client");
 
     api.use([
-        "deps",
+        "tracker",
         "underscore",
         "coffeescript",
         "check"
     ], "server");
 
-    api.add_files([
+    api.addFiles([
         "lib/pages.coffee",
         "test/tests.coffee"
     ]);
 
-    api.add_files([
+    api.addFiles([
         "client/templates.html",
         "client/controllers.coffee",
         "client/main.css",


### PR DESCRIPTION
I tweaked the code in setRouter to give unique route names. I also made some modifications to clean up the warnings after the 0.9.4 update. I had also fixed a pretty big bottleneck in paginating large sets of data, but realized after I was getting ready to contribute the fix...you had already taken care of it when you added live sort functionality. I've been using my own fork, and hadn't thought to pull your latest. 

Is there a specific reason that you are adding and using the _#{@id}_i field on the doc? I see where you are using it to sort the paginated collection on line 457, but why not use the @sort instead? I would think you could get by without the "addedAt" and "movedBefore" observers. When I was doing some initial tests, I didn't see the movedBefore fire...only "added", "changed", and "removed". Mostly saw the "added" and "removed" when the docs would jump from page to page, so I found as long as I updated the _#{@id}_p field and used the sort criteria...everything worked out. Maybe I'm missing something, though?
