### PR TITLE
remove backticks that caused require not defined

### DIFF
--- a/lib/pages.coffee
+++ b/lib/pages.coffee
@@ -103,7 +103,7 @@
   
   constructor: (collection, settings = {}) ->
     unless @ instanceof Meteor.Pagination
-      throw new Meteor.Error "missing-new", "The Meteor.Pagination instance has to be initiated with `new`"
+      throw new Meteor.Error "missing-new", "The Meteor.Pagination instance has to be initiated with 'new'"
     
     # Instance variables
     


### PR DESCRIPTION
In meteor 1.3.3 (possibly other versions) the backticks caused ReferenceError: require is not defined when including this package. switched backticks to single quotes per suggestion here: https://github.com/meteor/meteor/issues/7226.

Should fix issue reported  in Issue #211 